### PR TITLE
Update yew to 0.23, bump crate version to 0.10, fix tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "yew_icons"
 authors = ["Finn Bear"]
 license = "MIT"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 repository = "https://github.com/finnbear/yew_icons/"
 description = "Easily include a variety of SVG icons into your Yew app"
@@ -27,8 +27,8 @@ path = "src/generator.rs"
 required-features = ["_generator"]
 
 [dependencies]
-yew = { version = "0.22", features = [
-    "csr",
+yew = { version = "0.23", features = [
+    "csr"
 ] } #git = "https://github.com/yewstack/yew"}
 quote = { version = "1.0", optional = true }
 convert_case = { version = "0.5", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,10 @@ indicatif = { version = "0.18.0", optional = true }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["rt", "macros"] }
+yew = { version = "0.23", features = [
+    "csr", "ssr"
+] }
+yew_icons = { path = ".", features = ["lucide"]}
 
 [features]
 default = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,6 +175,6 @@ mod test {
         assert!(rendered.contains("2em"), "{data:?} {}", rendered);
         assert!(rendered.contains("3em"), "{data:?} {}", rendered);
 
-        //println!("{:?} => {}", icon_id, rendered);
+        // println!("{} => {}", data.name, rendered);
     }
 }

--- a/test-app/Cargo.toml
+++ b/test-app/Cargo.toml
@@ -11,7 +11,7 @@ incremental = true
 opt-level = "s"
 
 [dependencies]
-yew = { version = "0.22" }
+yew = { version = "0.23" }
 enum-iterator = "0.7"
 web-sys = { version = "0.3.70", features = [
     "Clipboard",


### PR DESCRIPTION
As the title says, yew has been updated to the latest version, and the crate version has been increased accordingly.

When testing, I noticed that the unit tests would not compile, hence I also fixed that by enabling the appropriate features in the dev dependencies.